### PR TITLE
Add more config options via script

### DIFF
--- a/hackmd/Dockerfile
+++ b/hackmd/Dockerfile
@@ -20,6 +20,7 @@ RUN bower install --allow-root
 
 # add config
 ADD config.json /hackmd/config.json
+ADD configure.js /hackmd/configure.js
 ADD .sequelizerc /hackmd/.sequelizerc
 ADD docker-entrypoint.sh /hackmd/docker-entrypoint.sh
 

--- a/hackmd/configure.js
+++ b/hackmd/configure.js
@@ -1,0 +1,63 @@
+var fs = require('fs');
+
+var config = JSON.parse(fs.readFileSync('config.json', 'utf8'));;
+
+config.production;
+if (process.env.DOMAIN)
+    config.production.domain=process.env.DOMAIN;
+
+if (process.env.URLPATH)
+    config.production.urlpath=process.env.URLPATH;
+
+if (process.env.PROTOCOLUSESSL)
+    config.production.protocolusessl=string2Boolean(process.env.PROTOCOLUSESSL);
+
+if (process.env.URLADDPORT)
+    config.production.urladdport=string2Boolean(process.env.URLADDPORT);
+
+if (process.env.USECDN)
+    config.production.usecdn=string2Boolean(process.env.USECDN);
+
+if (process.env.GITHUB_CLIENTID && process.env.GITHUB_CLIENTSECRET) {
+	config.production.github = {
+        clientID: process.env.GITHUB_CLIENTID,
+        clientSecret: process.env.GITHUB_CLIENTSECRET
+    };
+}
+
+if (process.env.TWITTER_CLIENTID && process.env.TWITTER_CLIENTSECRET) {
+    config.production.twitter = {
+        consumerKey: process.env.TWITTER_CLIENTID,
+        consumerSecret: process.env.TWITTER_CLIENTSECRET
+    };
+}
+
+if (process.env.FACEBOOK_CLIENTID && process.env.FACEBOOK_CLIENTSECRET) {
+    config.production.facebook = {
+        consumerKey: process.env.FACEBOOK_CLIENTID,
+        consumerSecret: process.env.FACEBOOK_CLIENTSECRET
+    };
+}
+
+if (process.env.GITLAB_CLIENTID && process.env.GITLAB_BASEURL && process.env.GITLAB_CLIENTSECRET) {
+    config.production.gitlab = {
+	    baseURL: process.env.GITLAB_BASEURL,
+        consumerKey: process.env.GITLAB_CLIENTID,
+        consumerSecret: process.env.GITLAB_CLIENTSECRET
+    };
+}
+
+jsonString = JSON.stringify(config);
+
+fs.writeFile("config.json", JSON.stringify(config), function(err) {
+    if(err) {
+        console.log(err);
+    } else {
+        console.log("Config file updated");
+    }
+});
+
+
+function string2Boolean(variable) {
+    return (variable === "1" || variable == "true");
+}

--- a/hackmd/docker-entrypoint.sh
+++ b/hackmd/docker-entrypoint.sh
@@ -8,5 +8,8 @@ fi
 # wait for db up
 sleep 3
 
+# configure hackmd based on environment variables
+node configure.js
+
 # run
 NODE_ENV='production' node app.js


### PR DESCRIPTION
Building an own container to allow custom configs is not really nice. So let's bring the config options to environment variables.

This should help to simplify the setup process a lot. (Please notice that there is currently no documentation and also not every config option possible)

Currently possible:

* `DOMAIN`
* `URLPATH`
* `PROTOCOLUSESSL`
* `URLADDPORT`
* `USECDN`
* `GITHUB_CLIENTID`
* `GITHUB_CLIENTSECRET`
* `TWITTER_CLIENTID`
* `TWITTER_CLIENTSECRET`
* `FACEBOOK_CLIENTID`
* `FACEBOOK_CLIENTSECRET`
* `GITLAB_BASEURL`
* `GITLAB_CLIENTID`
* `GITLAB_CLIENTSECRET`

Feel free to extend ;)