### PR TITLE
Improve build (alpine and proper config with env vars)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,6 @@ The default setting would use pre-build docker image, follow below steps to cust
 3. Run `docker-compose build --no-cache` in the docker terminal to build your own image.
 4. Then `docker-compose up` to startup.
 
-*Use `--build-arg VERSION=0.4.6` to build latest release. By default the latest dev version is build.*
+*Use `--build-arg VERSION=0.5.0` to build latest release. By default the latest dev version is build.*
 
 **Happy HackMD :smile:**

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Similar to backup steps, but last command is
 
 The default setting would use pre-build docker image, follow below steps to customize your HackMD.
 
-1. Modify `docker-compose.yml` at line 8 `image: hackmdio/hackmd:0.4.6` to `build: hackmd`.
+1. Modify `docker-compose.yml` at line 8 `image: hackmdio/hackmd:lite` to `build: hackmd`.
 2. Change the config files `hackmd/config.js` or `hackmd/config.json`, guide [here](https://github.com/hackmdio/hackmd/#configuration-files).
 3. Run `docker-compose build --no-cache` in the docker terminal to build your own image.
 4. Then `docker-compose up` to startup.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,20 @@
-hackmdpostgres:
-  image: postgres
-  environment:
-    - POSTGRES_USER=hackmd
-    - POSTGRES_PASSWORD=hackmdpass
-    - POSTGRES_DB=hackmd
-hackmd:
-  image: hackmdio/hackmd:0.5.0
-  environment:
-    - POSTGRES_USER=hackmd
-    - POSTGRES_PASSWORD=hackmdpass
-  links:
-    - hackmdpostgres
-  ports:
-    - "3000:3000"
+version: '2'
+services:
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_USER=hackmd
+      - POSTGRES_PASSWORD=hackmdpass
+      - POSTGRES_DB=hackmd
+  hackmd:
+    build: ./hackmd
+    ports:
+      - "3000:3000"
+    environment:
+      - HMD_DB_URL=postgres://hackmd:hackmdpass@postgres:5432/hackmd
+      - HMD_DOMAIN=localhost
+      - HMD_ALLOW_ANONYMOUS=true
+      - HMD_ALLOW_FREEURL=true
+      - HMD_EMAIL=false
+      - HMD_ALLOW_EMAIL_REGISTER=false
+      - HMD_IMAGE_UPLOAD_TYPE=filesystem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,5 @@ services:
     environment:
       - HMD_DB_URL=postgres://hackmd:hackmdpass@postgres:5432/hackmd
       - HMD_IMAGE_UPLOAD_TYPE=filesystem
+    volumes:
+      - /hackmd/public/uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,4 @@ services:
       - "3000:3000"
     environment:
       - HMD_DB_URL=postgres://hackmd:hackmdpass@postgres:5432/hackmd
-      - HMD_DOMAIN=localhost
-      - HMD_ALLOW_ANONYMOUS=true
-      - HMD_ALLOW_FREEURL=true
-      - HMD_EMAIL=false
-      - HMD_ALLOW_EMAIL_REGISTER=false
       - HMD_IMAGE_UPLOAD_TYPE=filesystem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - POSTGRES_PASSWORD=hackmdpass
       - POSTGRES_DB=hackmd
   hackmd:
-    build: ./hackmd
+    image: hackmdio/hackmd:lite
     ports:
       - "3000:3000"
     environment:

--- a/hackmd/.sequelizerc
+++ b/hackmd/.sequelizerc
@@ -4,5 +4,5 @@ module.exports = {
     'config':          path.resolve('config.json'),
     'migrations-path': path.resolve('lib', 'migrations'),
     'models-path':     path.resolve('lib', 'models'),
-    'url':             'postgres://hackmd:hackmdpass@hackmdpostgres:5432/hackmd'
+    'url':             process.env.HMD_DB_URL
 }

--- a/hackmd/Dockerfile
+++ b/hackmd/Dockerfile
@@ -34,7 +34,7 @@ EXPOSE 3000
 USER hackmd
 
 # Set some default config variables
-ENV NODE_ENV=docker
+ENV NODE_ENV=production
 
 # Add entrypoint and set command
 ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/hackmd/Dockerfile
+++ b/hackmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-alpine
+FROM node:6.9-alpine
 
 # Build arguments to change source url, branch or tag
 ARG SourceUrl=https://github.com/hackmdio/hackmd.git

--- a/hackmd/Dockerfile
+++ b/hackmd/Dockerfile
@@ -1,36 +1,43 @@
-FROM node:6.9-alpine
+FROM node:6-alpine
 
-ARG VERSION=master
+# Build arguments to change source url, branch or tag
+ARG SourceUrl=https://github.com/hackmdio/hackmd.git
+ARG SourceVersion=0.5.0
 
-# Add files
-ADD config.js /files/config.js
-ADD config.json /files/config.json
-ADD .sequelizerc /files/.sequelizerc
 
-RUN apk add --no-cache build-base alpine-sdk python git && \
-#   Add Source
-    git clone https://github.com/hackmdio/hackmd.git -b $VERSION /hackmd && \
-    cd /hackmd && \
+# Add configuraton files which seem to be required for a successful bild...
+ADD config.js config.json .sequelizerc /files/
+
+# Install all dependencies and build project
+RUN apk update && \
+    apk add --no-cache build-base python git && \
+    # Clone the source
+    git clone --depth 1 --branch $SourceVersion $SourceUrl /hackmd && \
+    # Symlink configuration files
     rm -f /hackmd/public/js/config.js && ln -s /files/config.js /hackmd/public/js/config.js && \
     rm -f /hackmd/config.json && ln -s /files/config.json /hackmd/config.json && \
     rm -f /hackmd/.sequelizerc && ln -s /files/.sequelizerc /hackmd/.sequelizerc && \
-
-#   Install dependencies
+    # Install NPM dependencies
+    cd /hackmd && \
     npm install && \
-    npm run build:prod && \
-
-#   Clean up image
+    # Build project! (Older versions uses npm script "build:prod", newer version uses just "build")
+    build_script_name="$(if grep -q 'build:prod' package.json; then echo 'build:prod'; else echo 'build'; fi)" && \
+    npm run $build_script_name && \
+    # Clean up this layer
     npm prune --production && \
-    apk del build-base alpine-sdk python git && \
+    apk del build-base python git && \
     adduser -u 10000 -h /hackmd/ -D -S hackmd && \
     chown -R hackmd /hackmd/
 
-ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-
 WORKDIR /hackmd
-
 EXPOSE 3000
-
 USER hackmd
 
+# Set some default config variables
+ENV NODE_ENV=docker
+ENV HMD_DB_URL=postgres://hackmd:hackmdpass@postgres:5432/hackmd
+ENV HMD_URL_ADDPORT=true
+
+# Add entrypoint and set command
+ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 CMD ["/usr/local/bin/docker-entrypoint.sh"]

--- a/hackmd/Dockerfile
+++ b/hackmd/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add --no-cache build-base alpine-sdk python git && \
     adduser -u 10000 -h /hackmd/ -D -S hackmd && \
     chown -R hackmd /hackmd/
 
-ADD docker-entrypoint.sh /hackmd/docker-entrypoint.sh
+ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 WORKDIR /hackmd
 
@@ -33,4 +33,4 @@ EXPOSE 3000
 
 USER hackmd
 
-ENTRYPOINT ["/hackmd/docker-entrypoint.sh"]
+CMD ["/usr/local/bin/docker-entrypoint.sh"]

--- a/hackmd/Dockerfile
+++ b/hackmd/Dockerfile
@@ -35,8 +35,6 @@ USER hackmd
 
 # Set some default config variables
 ENV NODE_ENV=docker
-ENV HMD_DB_URL=postgres://hackmd:hackmdpass@postgres:5432/hackmd
-ENV HMD_URL_ADDPORT=true
 
 # Add entrypoint and set command
 ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/hackmd/Dockerfile
+++ b/hackmd/Dockerfile
@@ -2,27 +2,26 @@ FROM node:6.9-alpine
 
 # Build arguments to change source url, branch or tag
 ARG SourceUrl=https://github.com/hackmdio/hackmd.git
-ARG SourceVersion=0.5.0
+ARG SourceVersion=master
 
 # Add configuraton files which seem to be required for a successful bild...
-ADD config.js config.json .sequelizerc /files/
+COPY config.json .sequelizerc /files/
 
 # Install all dependencies and build project
 RUN apk update && \
     apk add --no-cache build-base python git && \
     # Clone the source
     git clone --depth 1 --branch $SourceVersion $SourceUrl /hackmd && \
+    # Print the cloned version and clean up git files
+    cd /hackmd && \
+    git log --pretty=format:'%ad %h %d' --abbrev-commit --date=short -1 && echo "/n" && \
     rm -rf /hackmd/.git && \
     # Symlink configuration files
-    rm -f /hackmd/public/js/config.js && ln -s /files/config.js /hackmd/public/js/config.js && \
     rm -f /hackmd/config.json && ln -s /files/config.json /hackmd/config.json && \
     rm -f /hackmd/.sequelizerc && ln -s /files/.sequelizerc /hackmd/.sequelizerc && \
-    # Install NPM dependencies
-    cd /hackmd && \
+    # Install NPM dependencies and build project
     npm install && \
-    # Build project! (Older versions uses npm script "build:prod", newer version uses just "build")
-    build_script_name="$(if grep -q 'build:prod' package.json; then echo 'build:prod'; else echo 'build'; fi)" && \
-    npm run $build_script_name && \
+    npm run build && \
     # Clean up this layer
     npm prune --production && \
     apk del build-base python git && \

--- a/hackmd/Dockerfile
+++ b/hackmd/Dockerfile
@@ -4,7 +4,6 @@ FROM node:6.9-alpine
 ARG SourceUrl=https://github.com/hackmdio/hackmd.git
 ARG SourceVersion=0.5.0
 
-
 # Add configuraton files which seem to be required for a successful bild...
 ADD config.js config.json .sequelizerc /files/
 
@@ -13,6 +12,7 @@ RUN apk update && \
     apk add --no-cache build-base python git && \
     # Clone the source
     git clone --depth 1 --branch $SourceVersion $SourceUrl /hackmd && \
+    rm -rf /hackmd/.git && \
     # Symlink configuration files
     rm -f /hackmd/public/js/config.js && ln -s /files/config.js /hackmd/public/js/config.js && \
     rm -f /hackmd/config.json && ln -s /files/config.json /hackmd/config.json && \

--- a/hackmd/config.json
+++ b/hackmd/config.json
@@ -1,14 +1,1 @@
-{
-    "production": {
-        "urladdport": true,
-        "email": true,
-        "db": {
-            "username": "hackmd",
-            "password": "hackmdpass",
-            "database": "hackmd",
-            "host": "hackmdpostgres",
-            "port": "5432",
-            "dialect": "postgres"
-        }
-    }
-}
+{"docker": {}}

--- a/hackmd/config.json
+++ b/hackmd/config.json
@@ -1,1 +1,1 @@
-{"docker": {}}
+{"production": {}}

--- a/hackmd/docker-entrypoint.sh
+++ b/hackmd/docker-entrypoint.sh
@@ -8,5 +8,4 @@ fi
 sleep 3
 
 # run
-export NODE_ENV=production
 exec node app.js

--- a/hackmd/docker-entrypoint.sh
+++ b/hackmd/docker-entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-if [ -f .sequelizerc ];
-then
+if [ -f .sequelizerc ]; then
     node_modules/.bin/sequelize db:migrate
 fi
 
@@ -9,4 +8,5 @@ fi
 sleep 3
 
 # run
-NODE_ENV='production' node app.js
+export NODE_ENV=production
+exec node app.js

--- a/hackmd/docker-entrypoint.sh
+++ b/hackmd/docker-entrypoint.sh
@@ -8,4 +8,4 @@ fi
 sleep 3
 
 # run
-exec node app.js
+node app.js

--- a/hackmd/docker-entrypoint.sh
+++ b/hackmd/docker-entrypoint.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
 
-if [ -f .sequelizerc ]; then
-    node_modules/.bin/sequelize db:migrate
-fi
+# Ensure database has been migrated
+node_modules/.bin/sequelize db:migrate
 
-# wait for db up
+# Wait for database startup
 sleep 3
 
-# run
+# Run the app
 node app.js


### PR DESCRIPTION
Here is the `lite` branch but rebased on the latest master and with some added improvements.

- Uses the HMD_DB_URL also inside .sequelizerc for proper database configuration using only ENV vars.
- Upgraded docker-compose.yml to version 2 and build the subfolder hackmd instead of static image.
- Latest hackmd master has renamed build script to "build", this Dockerfile respects that.
- Makes a git clone of source without history for slightly faster build time.
- Emptied out config.json, using defaults instead and just overriding a few with environment variables in the Dockerfile (NODE_ENV , HMD_DB_URL, HMD_URL_ADDPORT). Other users can still base another Dockerfile on this one and add their custom config.json if they so wish.

Here at @erasys we are currently running this in our Marathon/Mesos cluster by only setting a few environment variables to configure it. Really awesome! 