### PR TITLE
Improve repository clone process

### DIFF
--- a/hackmd/Dockerfile
+++ b/hackmd/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:boron
 ENV DEBIAN_FRONTEND noninteractive
+ENV HACKMD_VERSION 0.5.0
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ wheezy-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
 	wget -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add - && \
 	apt-get update && \
@@ -8,7 +9,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ wheezy-pgdg main" > /etc/
 # source
 RUN mkdir /hackmd
 WORKDIR /hackmd
-RUN git clone https://github.com/hackmdio/hackmd.git /hackmd
+RUN git clone --branch ${HACKMD_VERSION:-master} --depth 1 https://github.com/hackmdio/hackmd.git /hackmd
 
 # npm, deps
 RUN npm install


### PR DESCRIPTION
 - Specified the branch/tag to clone and use shallow clone to speed up the clone process, and save some disk io/space.
 - Use an environment variable to save the version number to make future release much more easier.

Take git v2.11.0 and the current latest commit as example: https://github.com/hackmdio/hackmd/commit/d6822dd410f0356322c2cdb402a95ccbbdeeb208

A fully cloned repository will take 26868 bytes (27MB), but the shallow cloned with branch/tag specified will take only 13540 bytes ~= 14MB