### PR TITLE
Update compose to current version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,30 @@
-hackmdPostgres:
-  image: postgres
-  environment:
-    - POSTGRES_USER=hackmd
-    - POSTGRES_PASSWORD=hackmdpass
-    - POSTGRES_DB=hackmd
-hackmd:
-  image: hackmdio/hackmd:latest
-  environment:
-    - POSTGRES_USER=hackmd
-    - POSTGRES_PASSWORD=hackmdpass
-  links:
-    - hackmdPostgres:hackmdPostgres
-  ports:
-    - "3000:3000"
+version: '3'
+services:
+  database:
+    image: postgres:9.6-alpine
+    environment:
+      - POSTGRES_USER=hackmd
+      - POSTGRES_PASSWORD=hackmdpass
+      - POSTGRES_DB=hackmd
+    volumes:
+      - database:/var/lib/postgresql/data
+    networks:
+      backend:
+        aliases:
+          - hackmdPostgres
+    restart: always
+  app:
+    image: hackmdio/hackmd:0.5.1
+    environment:
+      - POSTGRES_USER=hackmd
+      - POSTGRES_PASSWORD=hackmdpass
+    ports:
+      - "3000:3000"
+    networks:
+      backend:
+    restart: always
+networks:
+  backend:
+
+volumes:
+  database:


### PR DESCRIPTION
Currently, the alias is mainly needed because the Database name is hard-coded in the `.squalizerc`.

It's the current compose file I use to run HackMB without the additional environment variables and with a more up-to-date Postgres version. So it's proven to work fine.

Important here:
The Postgres version should be fixed because newer Postgres versions do not work on datasets of an old one and there is currently no migration. (maybe it's better to use MySQL in future)

HackMD should also be pinned to the newest release version which makes sure that that the compose file doesn't accidently migrate to a newer version which breaks the database schema (like 0.4.0 to 0.5.0). And even when we managed it to migrate automatically I would suggest staying with fixed version numbers as they provide a more stable setup and make updates reasonable. 

