### PR TITLE
Add MySQL example and improve DB handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@
 version: '3'
 services:
   database:
-    # Don't upgrade postgres by simply changing the version number
-    # You need to migrate the Database to the new postgres version
+    # Don't upgrade PostgreSQL by simply changing the version number
+    # You need to migrate the Database to the new PostgreSQL version
     image: postgres:9.6-alpine
     environment:
       - POSTGRES_USER=hackmd
@@ -15,13 +15,33 @@ services:
       - database:/var/lib/postgresql/data
     networks:
       backend:
-        aliases:
-          - hackmdPostgres
-          - hackmdpostgres
     restart: always
+
+  # MySQL example
+  # Most of the documentation that applies to PostgreSQL applies also to MySQL
+  #database:
+  #    # You should be able to upgrade MySQL without problems
+  #    # but to make sure no even when a problem appears you
+  #    # should have a backup
+  #    image: mariadb:10
+  #    environment:
+  #      - MYSQL_USER=hackmd
+  #      - MYSQL_PASSWORD=hackmdpass
+  #      - MYSQL_DATABASE=hackmd
+  #      - MYSQL_ALLOW_EMPTY_PASSWORD=true
+  #    volumes:
+  #      - database:/var/lib/mysql
+  #      # This config provides UTF-8 support to the database by default
+  #      # If this config is not used, HackMD breaks as it tries to write
+  #      # UTF-8 to a latin database.
+  #      - ./resources/utf8.cnf:/etc/mysql/conf.d/utf8.cnf
+  #    networks:
+  #      backend:
+  #    restart: always
+
   app:
     # Uncomment the following section to build the image yourself:
-    #build: 
+    #build:
     #  context: .
     #  dockerfile: debian/Dockerfile
     #  args:
@@ -30,15 +50,15 @@ services:
     image: hackmdio/hackmd:1.0.1-ce
     environment:
       # DB_URL is formatted like: <databasetype>://<username>:<password>@<hostname>/<database>
-      # Other examples are: 
-      # - mysql://database:3306/database
+      # Other examples are:
+      # - mysql://hackmd:hackmdpassdatabase:3306/database
       # - sqlite:///data/sqlite.db (NOT RECOMMENDED)
       # - For details see the official sequelize docs: http://docs.sequelizejs.com/en/v3/
-      - HMD_DB_URL=postgres://hackmd:hackmdpass@hackmdPostgres:5432/hackmd
+      - HMD_DB_URL=postgres://hackmd:hackmdpass@database:5432/hackmd
     ports:
       # Ports that are published to the outside.
       # The latter port is the port inside the container. It should always stay on 3000
-      # If you only specify a port it'll published on all interfaces. If you want to use a 
+      # If you only specify a port it'll published on all interfaces. If you want to use a
       # local reverse proxy, you may want to listen on 127.0.0.1.
       # Example:
       # - "127.0.0.1:3000:3000"
@@ -49,10 +69,11 @@ services:
 
 # Define networks to allow best isolation
 networks:
-  # Internal network for communication with Postgres
+  # Internal network for communication with PostgreSQL/MySQL
   backend:
+    internal: true
 
 # Define named volumes so data stays in place
 volumes:
-  # Volume for Postgres database
+  # Volume for PostgreSQL/MySQL database
   database:

--- a/resources/utf8.cnf
+++ b/resources/utf8.cnf
@@ -1,0 +1,11 @@
+[client]
+default-character-set=utf8
+
+[mysql]
+default-character-set=utf8
+
+
+[mysqld]
+collation-server = utf8_unicode_ci
+init-connect='SET NAMES utf8'
+character-set-server = utf8


### PR DESCRIPTION
This commit provides makes the internal network truly internal and
removes the need for aliases since we handle DB_URLs correctly now.

Also we add an MySQL example including the needed MySQL config file to
make sure the database uses UTF-8 encoding. Otherwise HackMD fails for
example by opening the features page.