### PR TITLE
Set proper owner and permission to "public/uploads/" directory

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -18,6 +18,31 @@ RUN apk add --no-cache --virtual .download wget  ca-certificates && \
     rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     apk del .download
 
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+    \
+    apk add --no-cache --virtual .gosu-deps \
+        dpkg \
+        gnupg \
+        openssl \
+    ; \
+    \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    \
+# verify the signature
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver pgp.mit.edu --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    \
+    chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+    gosu nobody true; \
+    \
+    apk del .gosu-deps
+
 # Add configuraton files
 COPY config.json .sequelizerc /files/
 
@@ -46,8 +71,9 @@ RUN apk add --no-cache --virtual .dep build-base python git bash && \
 
 WORKDIR /hackmd
 EXPOSE 3000
-USER hackmd
 
 # Add entrypoint and set command
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
+CMD ["node", "app.js"]

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -13,6 +13,22 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
+ENV GOSU_VERSION 1.10
+RUN set -ex; \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    \
+# verify the signature
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --keyserver pgp.mit.edu --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    \
+    chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+    gosu nobody true
+
 # Add configuraton files
 COPY config.json .sequelizerc /files/
 
@@ -47,8 +63,9 @@ RUN apt-get update && \
 
 WORKDIR /hackmd
 EXPOSE 3000
-USER hackmd
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
+CMD ["node", "app.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$DB_SOCKET" != "" ]; then
     dockerize -wait tcp://${DB_SOCKET} -timeout 30s
 fi
 
-node_modules/.bin/sequelize db:migrate
+gosu hackmd node_modules/.bin/sequelize db:migrate
 
 # Print warning if local data storage is used but no volume is mounted
 [ "$HMD_IMAGE_UPLOAD_TYPE" = "filesystem" ] && { mountpoint -q ./public/uploads || {
@@ -30,9 +30,14 @@ node_modules/.bin/sequelize db:migrate
     ";
 } ; }
 
+# Change owner and permission if filesystem backend is used
+if [ "$HMD_IMAGE_UPLOAD_TYPE" = "filesystem" ]; then
+    chown -R hackmd ./public/uploads
+    chmod 700 ./public/uploads
+fi
+
 # Sleep to make sure everything is fine...
 sleep 3
 
 # run
-node app.js
-
+exec gosu hackmd "$@"


### PR DESCRIPTION
To fix permission problems when using filesystem backend.

```
$ docker run -p 3000:3000 -v /srv/hackmd:/hackmd/public/uploads -e HMD_DB_URL=<database URL> -e HMD_IMAGE_UPLOAD_TYPE=filesystem -d hackmdio/hackmd:alpine
<container id>
```

After attempt to upload image:

```
$ docker logs <container id>
(snip)
2018-04-19T08:54:46.113Z - error: An uncaught exception has occured.
2018-04-19T08:54:46.114Z - error:  Error: EACCES: permission denied, open 'public/uploads/upload_54e044b9ec7da65b3d1f622ecf5d8381.png'
2018-04-19T08:54:46.114Z - error: Process will exit now.
```