### PR TITLE
Add some security features to compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
     # Don't upgrade PostgreSQL by simply changing the version number
     # You need to migrate the Database to the new PostgreSQL version
     image: postgres:9.6-alpine
+    mem_limit: 256mb
+    memswap_limit: 512mb
+    read_only: true
+    tmpfs:
+      - /run/postgresql:size=512K
     environment:
       - POSTGRES_USER=hackmd
       - POSTGRES_PASSWORD=hackmdpass
@@ -48,6 +53,14 @@ services:
     #    - "VERSION=master"
     #    - "HACKMD_REPOSITORY=https://github.com/hackmdio/hackmd.git"
     image: hackmdio/hackmd:1.2.0
+    mem_limit: 256mb
+    memswap_limit: 512mb
+    read_only: true
+    tmpfs:
+      - /tmp:size=512K
+      - /hackmd/tmp:size=1M
+      # Make sure you remove this when you use filesystem as upload type
+      - /hackmd/public/uploads:size=10M
     environment:
       # DB_URL is formatted like: <databasetype>://<username>:<password>@<hostname>/<database>
       # Other examples are:


### PR DESCRIPTION
We should limit memory usage and make containers read-only to harden 
running container against compromised software.