### PR TITLE
Add ca-certificates to gosu install

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -23,6 +23,8 @@ COPY gosu-gpg.key /tmp/gosu.key
 RUN set -ex; \
     \
     apk add --no-cache --virtual .gosu-deps \
+        wget \
+        ca-certificates \
         dpkg \
         gnupg \
         openssl \


### PR DESCRIPTION
Looks like there was a change in alpine that removed ca-certicates from
the inplicit dependencies of the dependencies we install for gosu and
this way we lost the ability to download gosu from GitHub thanks to
missing certiticates