### PR TITLE
fix typo in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     environment:
       # DB_URL is formatted like: <databasetype>://<username>:<password>@<hostname>/<database>
       # Other examples are:
-      # - mysql://hackmd:hackmdpassdatabase:3306/database
+      # - mysql://hackmd:hackmdpass@database:3306/hackmd
       # - sqlite:///data/sqlite.db (NOT RECOMMENDED)
       # - For details see the official sequelize docs: http://docs.sequelizejs.com/en/v3/
       - HMD_DB_URL=postgres://hackmd:hackmdpass@database:5432/hackmd


### PR DESCRIPTION
mysql's db url should be ``mysql://hackmd:hackmdpass@database:3306/hackmd`` rather than ``mysql://hackmd:hackmdpassdatabase:3306/database``